### PR TITLE
Force Simulator Language fix

### DIFF
--- a/lib/snapshot.rb
+++ b/lib/snapshot.rb
@@ -12,6 +12,7 @@ require 'snapshot/collector'
 require 'snapshot/options'
 require 'snapshot/update'
 require 'snapshot/fixes/simulator_zoom_fix'
+require 'snapshot/fixes/simulator_language_fix'
 
 require 'fastlane_core'
 

--- a/lib/snapshot/fixes/simulator_language_fix.rb
+++ b/lib/snapshot/fixes/simulator_language_fix.rb
@@ -1,0 +1,31 @@
+module Snapshot
+	module Fixes
+		class SimulatorLanguageFix
+	      def self.patch(language)
+	        # First we need to kill the simulator
+	        `killall iOS Simulator &> /dev/null`
+	
+	        FastlaneCore::Simulator.all.each do |simulator|
+	          simulator_udid = simulator.udid
+			  sim_pref_path = sim_prefs(simulator_udid)
+			  sim_language = language.tr("-", "_")
+			  
+			  Helper.log.debug "Patching simulator #{simulator.name} to language #{sim_language}"
+			  Helper.log.debug sim_pref_path
+			  
+			  command = "defaults write '#{sim_pref_path}' 'AppleLocale' '#{sim_language}'"
+	          puts command.yellow if $debug
+	          `#{command}`
+	          
+	          command2 = "defaults write '#{sim_pref_path}' 'AppleLanguages' '(#{sim_language})'"
+	          puts command2.yellow if $debug
+	          `#{command2}`
+	        end
+	      end
+	
+	      def self.sim_prefs(sim_udid)
+	        File.join(File.expand_path("~"), "Library", "Developer", "CoreSimulator", "Devices", sim_udid, "data", "Library", "Preferences", ".GlobalPreferences.plist")
+	      end
+      end
+	end
+end	

--- a/lib/snapshot/fixes/simulator_language_fix.rb
+++ b/lib/snapshot/fixes/simulator_language_fix.rb
@@ -1,31 +1,32 @@
 module Snapshot
-	module Fixes
-		class SimulatorLanguageFix
-	      def self.patch(language)
-	        # First we need to kill the simulator
-	        `killall iOS Simulator &> /dev/null`
-	
-	        FastlaneCore::Simulator.all.each do |simulator|
-	          simulator_udid = simulator.udid
-			  sim_pref_path = sim_prefs(simulator_udid)
-			  sim_language = language.tr("-", "_")
-			  
-			  Helper.log.debug "Patching simulator #{simulator.name} to language #{sim_language}"
-			  Helper.log.debug sim_pref_path
-			  
-			  command = "defaults write '#{sim_pref_path}' 'AppleLocale' '#{sim_language}'"
-	          puts command.yellow if $debug
-	          `#{command}`
-	          
-	          command2 = "defaults write '#{sim_pref_path}' 'AppleLanguages' '(#{sim_language})'"
-	          puts command2.yellow if $debug
-	          `#{command2}`
-	        end
-	      end
-	
-	      def self.sim_prefs(sim_udid)
-	        File.join(File.expand_path("~"), "Library", "Developer", "CoreSimulator", "Devices", sim_udid, "data", "Library", "Preferences", ".GlobalPreferences.plist")
-	      end
+  module Fixes
+    class SimulatorLanguageFix
+      def self.patch(language)
+        # First we need to kill the simulator
+        `killall iOS Simulator &> /dev/null`
+  
+        FastlaneCore::Simulator.all.each do |simulator|
+          simulator_udid = simulator.udid
+
+          sim_pref_path = sim_prefs(simulator_udid)
+          sim_language = language.tr("-", "_") # plist takes unterscores
+        
+          Helper.log.debug "Patching simulator #{simulator.name} to language #{sim_language}"
+          Helper.log.debug sim_pref_path
+        
+          command = "defaults write '#{sim_pref_path}' 'AppleLocale' '#{sim_language}'"
+          puts command.yellow if $debug
+          `#{command}`
+          
+          command2 = "defaults write '#{sim_pref_path}' 'AppleLanguages' '(#{sim_language})'"
+          puts command2.yellow if $debug
+          `#{command2}`
+        end
       end
-	end
-end	
+  
+      def self.sim_prefs(sim_udid)
+        File.join(File.expand_path("~"), "Library", "Developer", "CoreSimulator", "Devices", sim_udid, "data", "Library", "Preferences", ".GlobalPreferences.plist")
+      end
+    end
+  end
+end  

--- a/lib/snapshot/fixes/simulator_language_fix.rb
+++ b/lib/snapshot/fixes/simulator_language_fix.rb
@@ -12,7 +12,6 @@ module Snapshot
           sim_language = language.tr("-", "_") # plist takes unterscores
         
           Helper.log.debug "Patching simulator #{simulator.name} to language #{sim_language}"
-          Helper.log.debug sim_pref_path
         
           command = "defaults write '#{sim_pref_path}' 'AppleLocale' '#{sim_language}'"
           puts command.yellow if $debug

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -47,6 +47,11 @@ module Snapshot
                                      default_value: [
                                        'en-US'
                                      ]),
+        FastlaneCore::ConfigItem.new(key: :force_simulator_language,
+                                     env_name: "SNAPSHOT_FORCE_SIMULATOR_LANGUAGE",
+                                     description: "This option will execute a fix and patch all simulators to the desired language to fix some issues with NSDateFormatter using the english locale",
+                                     is_string: false,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "SNAPSHOT_OUTPUT_DIRECTORY",

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -55,7 +55,7 @@ module Snapshot
       File.write("/tmp/language.txt", language)
 
       Fixes::SimulatorZoomFix.patch
-      Fixes::SimulatorLanguageFix.patch(language)
+      Fixes::SimulatorLanguageFix.patch(language) if Snapshot.config[:force_simulator_language]
 
       command = TestCommandGenerator.generate(device_type: device_type)
 

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -55,6 +55,7 @@ module Snapshot
       File.write("/tmp/language.txt", language)
 
       Fixes::SimulatorZoomFix.patch
+      Fixes::SimulatorLanguageFix.patch(language)
 
       command = TestCommandGenerator.generate(device_type: device_type)
 


### PR DESCRIPTION
There are some issues with the NSDateFormatter not using the language defined with the parameters and still using the english locale to create a localized date string.
This patch adds the `force_simulator_language`option which is currently `false` by  default that will patch the simulators to the correct language defined in the Snapfile.

This prevents an ugly fix in the project code to set the correct locale for NSDateFormatter.
Also `NSLocale.currentLocale` returns `en_US` if the simulator itself is not set to the desired language 