### PR TITLE
Add options to add photos and videos to a simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ By default `snapshot` automatically retries running UI Tests if they fail. This 
 snapshot --number_of_retries 3
 ```
 
+Add photos and/or videos to the simulator before running `snapshot`
+
+```sh
+snapshot --add_photos MyTestApp/Assets/demo.jpg --add_videos MyTestApp/Assets/demo.mp4
+```
+
 For a list for all available options run
 
 ```sh
@@ -248,6 +254,9 @@ launch_arguments("-username Felix")
 output_directory './screenshots'
 
 clear_previous_screenshots true
+
+add_photos ["MyTestApp/Assets/demo.jpg"]
+
 ```
 
 ### Completely reset all simulators

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -88,6 +88,18 @@ module Snapshot
                                      optional: true,
                                      description: "The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)",
                                      default_value: ENV["SNAPSHOT_APP_IDENTITIFER"] || CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)),
+        FastlaneCore::ConfigItem.new(key: :add_photos,
+                                     env_name: 'SNAPSHOT_PHOTOS',
+                                     short_option: "-j",
+                                     description: "A list of photos that should be added to the simulator before running the application",
+                                     type: Array,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :add_videos,
+                                     env_name: 'SNAPSHOT_VIDEOS',
+                                     short_option: "-u",
+                                     description: "A list of videos that should be added to the simulator before running the application",
+                                     type: Array,
+                                     optional: true),
 
         # Everything around building
         FastlaneCore::ConfigItem.new(key: :buildlog_path,

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -123,6 +123,9 @@ module Snapshot
         uninstall_app(device_type)
       end
 
+      add_media(device_type, :photo, Snapshot.config[:add_photos]) if Snapshot.config[:add_photos]
+      add_media(device_type, :video, Snapshot.config[:add_videos]) if Snapshot.config[:add_videos]
+
       command = TestCommandGenerator.generate(device_type: device_type)
 
       UI.header("#{device_type} - #{language}")
@@ -179,6 +182,21 @@ module Snapshot
       Helper.log.info "Erasing #{device_type}...".yellow
 
       `xcrun simctl erase #{device_udid} &> /dev/null`
+    end
+
+    def add_media(device_type, media_type, paths)
+      media_type = media_type.to_s
+
+      UI.verbose "Adding #{media_type}s to #{device_type}..."
+      device_udid = TestCommandGenerator.device_udid(device_type)
+
+      UI.message "Launch Simulator #{device_type}"
+      Helper.backticks("xcrun instruments -w #{device_udid} &> /dev/null")
+
+      paths.each do |path|
+        UI.message "Adding '#{path}'"
+        Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} &> /dev/null")
+      end
     end
 
     def clear_previous_screenshots


### PR DESCRIPTION
Which is useful when your app makes use of your photo library, but you don't want to use the stock items available by default on a simulator.

This code does work, but the short options are now just set to something that was available, but should probably be overthought. Maybe there's a way to have an option be an array, without the requirement of a short option?


